### PR TITLE
fix: rover not starting to beep when an invalid pipeline was met

### DIFF
--- a/home_debix/ase/bin/boot.py
+++ b/home_debix/ase/bin/boot.py
@@ -234,7 +234,18 @@ def startup():
             auth=("debix", "debix")
         )
 
-        print(f"Status code: {response}")
+        print(f"Status code: {response.status_code}")
+
+        if response.status_code != 200:
+            print("Error while setting pipeline, is your race.yaml correct?")
+            try:
+                buzzer_alarm()
+            except KeyboardInterrupt:
+                print("Exiting")
+                buzzer_off()
+                buzzer_off()
+                return
+
         
         buzzer_countdown()
 


### PR DESCRIPTION
Rover now starts beeping if the pipeline has issues (/pipeline doesn't return 200)