### PR TITLE
Added "tzdata" to devcontainer and task for storing flash date and time

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,6 +20,18 @@ RUN apt-get update && apt-get install -y curl \
 # Python 3 install
 RUN apt-get install -y python3 python3-pip language-pack-en sshpass
 
+
+# ──────────────────────────────────────────────────────────────────
+# Timezone setup: install tzdata and configure Europe/Amsterdam
+# ──────────────────────────────────────────────────────────────────
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata && \
+    ln -fs /usr/share/zoneinfo/Europe/Amsterdam /etc/localtime && \
+    echo "Europe/Amsterdam" > /etc/timezone && \
+    dpkg-reconfigure -f noninteractive tzdata
+
+ENV TZ="Europe/Amsterdam"
+
 # This is to ensure that the host where the docker container is built has the same uid/gid
 # as the user used inside the container. Otherwise, permission issues.
 ARG HOST_UID

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -401,11 +401,28 @@
     - "/usr/lib/systemd/system-shutdown/rover-shutdown"
     - "/usr/lib/systemd/system-shutdown/system-shutdown"
 
+
+- name: Set timezone to Europe/Amsterdam
+  become: true
+  ansible.builtin.timezone:
+    name: Europe/Amsterdam
+  tags: 
+    - setup
+    - timezone
+
+- name: Ensure NTP sync is enabled
+  become: true
+  ansible.builtin.command: timedatectl set-ntp true
+  tags: 
+    - setup
+    - timezone
+
 # ───────────────────────────────────────────────────────
 # Write controller-time to the controller’s log
 # ───────────────────────────────────────────────────────
 - name: Append this flash event to history (controller side)
-  tags: [flash]
+  tags: 
+    - flash
   delegate_to: localhost
   lineinfile:
     path: "{{ playbook_dir }}/flash_history.log"
@@ -417,7 +434,8 @@
 # Write controller-time to the rover’s log
 # ───────────────────────────────────────────────────────
 - name: Append this flash event to the device’s own history
-  tags: [flash]
+  tags: 
+    - flash
   become: true
   lineinfile:
     path: /etc/roverd/flash_history.log

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -401,17 +401,29 @@
     - "/usr/lib/systemd/system-shutdown/rover-shutdown"
     - "/usr/lib/systemd/system-shutdown/system-shutdown"
 
-- name: Append this flash event to history (with correct local time)
+# ───────────────────────────────────────────────────────
+# Write controller-time to the controller’s log
+# ───────────────────────────────────────────────────────
+- name: Append this flash event to history (controller side)
+  tags: [flash]
+  delegate_to: localhost
   lineinfile:
     path: "{{ playbook_dir }}/flash_history.log"
     create: yes
     insertafter: EOF
     line: "{{ inventory_hostname }} flashed at {{ lookup('pipe','date --iso-8601=seconds') }}"
-  delegate_to: localhost
-  tags:
-    - flash
 
-
+# ───────────────────────────────────────────────────────
+# Write controller-time to the rover’s log
+# ───────────────────────────────────────────────────────
+- name: Append this flash event to the device’s own history
+  tags: [flash]
+  become: true
+  lineinfile:
+    path: /etc/roverd/flash_history.log
+    create: yes
+    insertafter: EOF
+    line: "{{ lookup('pipe','date --iso-8601=seconds') }}"
 
 
 

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -401,7 +401,15 @@
     - "/usr/lib/systemd/system-shutdown/rover-shutdown"
     - "/usr/lib/systemd/system-shutdown/system-shutdown"
 
-
+- name: Append this flash event to history (with correct local time)
+  lineinfile:
+    path: "{{ playbook_dir }}/flash_history.log"
+    create: yes
+    insertafter: EOF
+    line: "{{ inventory_hostname }} flashed at {{ lookup('pipe','date --iso-8601=seconds') }}"
+  delegate_to: localhost
+  tags:
+    - flash
 
 
 


### PR DESCRIPTION
Added new step in the dockerfile to install "tzdata" and configure the correct time-zone. Then added a new task which stores the flash time of the corresponding rover in "flash_history.log"